### PR TITLE
Use RFC 6979

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 BitUniverse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/src/main/java/com/bitshares/bitshareswallet/wallet/graphene/chain/signed_transaction.java
+++ b/app/src/main/java/com/bitshares/bitshareswallet/wallet/graphene/chain/signed_transaction.java
@@ -12,14 +12,14 @@ public class signed_transaction extends transaction {
     List<compact_signature> signatures = new ArrayList<>();
 
     public void sign(types.private_key_type privateKeyType, sha256_object chain_id) {
-        sha256_object digest = sig_digest(chain_id);
         while(true) {
+            sha256_object digest = sig_digest(chain_id);
             compact_signature sig = privateKeyType.getPrivateKey().sign_compact(digest, true);
             if(sig != null) {
                 signatures.add(sig);
                 break;
             }
-            expiration.setTime(expiration.getTime()+1);
+            expiration.setSeconds(expiration.getSeconds() + 1);
         }
     }
 }

--- a/app/src/main/java/com/bitshares/bitshareswallet/wallet/graphene/chain/signed_transaction.java
+++ b/app/src/main/java/com/bitshares/bitshareswallet/wallet/graphene/chain/signed_transaction.java
@@ -13,6 +13,13 @@ public class signed_transaction extends transaction {
 
     public void sign(types.private_key_type privateKeyType, sha256_object chain_id) {
         sha256_object digest = sig_digest(chain_id);
-        signatures.add(privateKeyType.getPrivateKey().sign_compact(digest, true));
+        while(true) {
+            compact_signature sig = privateKeyType.getPrivateKey().sign_compact(digest, true);
+            if(sig != null) {
+                signatures.add(sig);
+                break;
+            }
+            expiration.setTime(expiration.getTime()+1);
+        }
     }
 }

--- a/app/src/main/java/com/bitshares/bitshareswallet/wallet/private_key.java
+++ b/app/src/main/java/com/bitshares/bitshareswallet/wallet/private_key.java
@@ -110,29 +110,27 @@ public class private_key {
 
     public compact_signature sign_compact(sha256_object digest, boolean require_canonical ) {
         compact_signature signature = null;
-        try {
-            final HmacPRNG prng = new HmacPRNG(key_data);
-            RandomSource randomSource = new RandomSource() {
-                @Override
-                public void nextBytes(byte[] bytes) {
-                    prng.nextBytes(bytes);
-                }
-            };
 
-            while (true) {
-                InMemoryPrivateKey inMemoryPrivateKey = new InMemoryPrivateKey(key_data);
-                SignedMessage signedMessage = inMemoryPrivateKey.signHash(new Sha256Hash(digest.hash), randomSource);
-                byte[] byteCompact = signedMessage.bitcoinEncodingOfSignature();
-                signature = new compact_signature(byteCompact);
-
-                boolean bResult = public_key.is_canonical(signature);
-                if (bResult == true) {
-                    break;
-                }
+        SecureRandom secureRandom = new SecureRandom();
+        RandomSource randomSource = new RandomSource() {
+            @Override
+            public void nextBytes(byte[] bytes) {
+                secureRandom.nextBytes(bytes);
             }
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
+        };
+
+        while (true) {
+            InMemoryPrivateKey inMemoryPrivateKey = new InMemoryPrivateKey(key_data);
+            SignedMessage signedMessage = inMemoryPrivateKey.signHash(new Sha256Hash(digest.hash), randomSource);
+            byte[] byteCompact = signedMessage.bitcoinEncodingOfSignature();
+            signature = new compact_signature(byteCompact);
+
+            boolean bResult = public_key.is_canonical(signature);
+            if (bResult == true) {
+                break;
+            }
         }
+
 
         return signature;
     }

--- a/app/src/test/java/com/bitshares/bitshareswallet/wallet/graphene/chain/signed_transactionTest.java
+++ b/app/src/test/java/com/bitshares/bitshareswallet/wallet/graphene/chain/signed_transactionTest.java
@@ -1,0 +1,44 @@
+package com.bitshares.bitshareswallet.wallet.graphene.chain;
+
+import com.bitshares.bitshareswallet.wallet.fc.crypto.sha256_object;
+import com.bitshares.bitshareswallet.wallet.private_key;
+
+import org.bitcoinj.core.ECKey;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import de.bitsharesmunich.graphenej.BrainKey;
+
+import static org.junit.Assert.*;
+
+public class signed_transactionTest {
+
+    @Test
+    public void sign() {
+        int num_tries = 100;
+
+        BrainKey brainKey = new BrainKey("This is a test", 1);
+        ECKey ecKey = brainKey.getPrivateKey();
+        private_key pK = new private_key(ecKey.getPrivKeyBytes());
+
+        types.private_key_type privateKey = new types.private_key_type(pK);
+
+        sha256_object chain_id = sha256_object.create_from_string("ABC123");
+
+        HashSet<compact_signature> signatures = new HashSet<compact_signature>();
+        
+        for(int i = 0; i < num_tries; ++i)
+        {
+            signed_transaction trx = new signed_transaction();
+            trx.expiration = new java.util.Date();
+            trx.operations = new ArrayList<operations.operation_type>();
+            trx.extensions = new HashSet<types.void_t>();
+            trx.sign(privateKey, chain_id);
+            signatures.add(trx.signatures.get(0));
+        }
+
+        assertEquals(num_tries, signatures.size());
+    }
+}


### PR DESCRIPTION
The PRNG should use RFC 6979 for added security when generating transaction signatures.